### PR TITLE
Building production version now works again: pinning reactstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-slider": "^0.11.0",
     "react-transition-group": "^1.1.3",
     "react-treebeard": "^2.0.0",
-    "reactstrap": "^5.0.0-alpha.4",
+    "reactstrap": "5.0.0-beta",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",
     "throttle-debounce": "^1.0.1"


### PR DESCRIPTION
Building production version now works again: pinning reactstrap version to 5.0.0-beta