### PR TITLE
Diagpagesubtitutes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ RUN npm run build
 # Install `serve` to run the application.
 RUN npm install -g serve
 # Set the command to start the node server.
-CMD echo "const config = { 'backendHost': '${BACKEND}', 'adagucServicesHost': '${COMPUTE}',  'adagucViewerURL' : '${VIEWER}', 'staticWMS' : '${STATICWMS}' };" > /frontend/c3s-magic-frontend/dist/config.js && serve -s dist --listen 80
+CMD echo "const config = { 'backendHost': '${BACKEND}', 'adagucServicesHost': '${COMPUTE}',  'adagucViewerURL' : '${VIEWER}', 'staticWMS' : '${STATICWMS}', 'dataURL' : '${DATAURL}' };" > /frontend/c3s-magic-frontend/dist/config.js && serve -s dist --listen 80
 
 EXPOSE 80
 
 #docker build -t c3s-magic-frontend .
-#docker run -e COMPUTE="https://compute:9000" -e BACKEND="https://portal.c3s-magic.eu/backend" -e VIEWER=https://portal.c3s-magic.eu/adaguc-viewer -e "STATICWMS=https://portal.c3s-magic.eu/backend/wms" -p 8080:80 -it c3s-magic-frontend
+#docker run -e COMPUTE="https://compute:9000" -e BACKEND="https://portal.c3s-magic.eu/backend" -e VIEWER=https://portal.c3s-magic.eu/adaguc-viewer -e "STATICWMS=https://portal.c3s-magic.eu/backend/wms" -e "DATAURL=https://portal-dev.c3s-magic.eu/" -p 8080:80 -it c3s-magic-frontend
 

--- a/src/components/Basket/BasketTreeComponent.jsx
+++ b/src/components/Basket/BasketTreeComponent.jsx
@@ -10,9 +10,6 @@ import { withRouter } from 'react-router';
 import Moment from 'react-moment';
 import Icon from 'react-fa';
 import FileUploadComponent from '../FileUploadComponent';
-import { ENOBUFS } from 'constants';
-
-var fileDownload = require('js-file-download');
 
 class BasketTreeComponent extends Component {
   constructor (props) {
@@ -26,6 +23,7 @@ class BasketTreeComponent extends Component {
     this.previewFile = this.previewFile.bind(this);
     this.reloadBasket = this.reloadBasket.bind(this);
     this.uploadBasketItem = this.uploadBasketItem.bind(this);
+    this.onDoubleClick = this.onDoubleClick.bind(this);    
 
     decorators.Header = (properties) => {
       if (!properties.node.type === 'NODE') return;
@@ -35,8 +33,9 @@ class BasketTreeComponent extends Component {
       const iconStyle = { marginRight: '5px' };
 
       if (properties.node.type === 'LEAF') {
+        console.log(properties.node);
         return (
-          <div style={{ verticalAlign: 'top', color: '#000000' }}>
+          <div style={{ verticalAlign: 'top', color: '#000000', cursor: 'default', backgroundColor: properties.node.active === true ? '#00A0FF' : null }}>
             <div style={style.title}>
               <div>
                 <i className={iconClass} style={iconStyle} />
@@ -74,10 +73,20 @@ class BasketTreeComponent extends Component {
     if (node.children) {
       node.toggled = toggled;
     }
-
     /* When toggled, preview is always not active. */
     this.setState({ cursor: node, previewActive: false });
-    console.log(node);
+    
+    if (this.clickedNode === node) {
+      this.onDoubleClick(node);
+      this.clickedNode = null;
+    }
+    this.clickedNode = node;
+    setTimeout(() => {
+      this.clickedNode = null;
+    }, 300);
+
+  }
+  onDoubleClick (node) {
     if (node.type === 'LEAF') {
       if (node.httpurl.endsWith('.png')) {
 
@@ -247,7 +256,6 @@ BasketTreeComponent.propTypes = {
   data: PropTypes.object,
   dispatch: PropTypes.func.isRequired,
   actions: PropTypes.object.isRequired,
-  router: PropTypes.object,
   accessToken: PropTypes.string,
   backend: PropTypes.string
 };

--- a/src/components/WPS/JSONViewer.jsx
+++ b/src/components/WPS/JSONViewer.jsx
@@ -1,0 +1,36 @@
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import axios from 'axios';
+import ReactJson from 'react-json-view';
+export default class JSONViewer extends Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      url: props.url,
+      data: null
+    };
+  }
+
+  componentDidMount () {
+    axios({
+      method: 'get',
+      url: this.state.url,
+      withCredentials: true
+    }).then(src => {
+      this.setState({ data: src.data });
+    }).catch((e) => {
+      console.error(e);
+    });
+  }
+
+  render () {
+    return (<div className='wpsOutputComponentContainer'>
+      <ReactJson style={{ fontSize:'10px', lineHeight:'12px' }} src={this.state.data} />
+    </div>);
+  }
+}
+
+JSONViewer.propTypes = {
+  url: PropTypes.string
+};

--- a/src/components/WPS/RenderWPSProcessOutput.jsx
+++ b/src/components/WPS/RenderWPSProcessOutput.jsx
@@ -4,6 +4,7 @@ import { Row, Col, Card, CardBody, CardText, CardLink, CardTitle } from 'reactst
 
 import ClickableImage from '../ClickableImage';
 import YMLViewer from './YMLViewer';
+import JSONViewer from './JSONViewer';
 import TXTViewer from './TXTViewer';
 import SVGViewer from './SVGViewer';
 import ADAGUCViewerComponent from '../ADAGUCViewerComponent';
@@ -69,6 +70,10 @@ export default class RenderWPSProcessOutput extends Component {
         if (output.reference.endsWith('.yml')) {
           output.esmRecipe = output.reference;
         }
+        /* Check if is JSON */
+        if (output.reference.endsWith('.json') || output.reference.endsWith('.wpssettings')) {
+          output.jsonViewer = output.reference;
+        }
         /* Check if this is a textfile */
         if (output.reference.endsWith('.txt')) {
           output.txtViewer = output.reference;
@@ -101,6 +106,7 @@ export default class RenderWPSProcessOutput extends Component {
           </Row>)
           }
           { output.esmRecipe && (<Row><Col xs='10'><YMLViewer url={output.esmRecipe} /></Col></Row>) }
+          { output.jsonViewer && (<Row><Col xs='10'><JSONViewer url={output.jsonViewer} /></Col></Row>) }
           { output.txtViewer && (<Row><Col xs='10'><TXTViewer url={output.txtViewer} /></Col></Row>) }
           { output.svgViewer && (<Row><Col xs='12'><SVGViewer url={output.svgViewer} /></Col></Row>) }
           { output.netcdfOpenDAP && (<Row><Col xs='10'>

--- a/src/components/WPS/YMLViewer.jsx
+++ b/src/components/WPS/YMLViewer.jsx
@@ -22,11 +22,10 @@ export default class YMLViewer extends Component {
       this.setState({ data: (YAML.parse(src.data)) });
     }).catch((e) => {
       console.error(e);
-    })
+    });
   }
 
   render () {
-    const { closeCallback } = this.props;
     return (<div className='wpsOutputComponentContainer'>
       <ReactJson style={{ fontSize:'10px', lineHeight:'12px' }} src={this.state.data} />
     </div>);
@@ -34,6 +33,5 @@ export default class YMLViewer extends Component {
 }
 
 YMLViewer.propTypes = {
-  url: PropTypes.string,
-  closeCallback: PropTypes.func
+  url: PropTypes.string
 };

--- a/src/components/WPSDemoCopernicus.jsx
+++ b/src/components/WPSDemoCopernicus.jsx
@@ -59,6 +59,13 @@ class WPSDemoCopernicus extends Component {
   }
 
   fetchProcesses () {
+    if (!this.props.compute || !this.props.compute.length || this.props.compute.length === 0) {
+      this.setState({
+        isBusy: false,
+        isBusyMessage: 'No compute nodes set'
+      });
+      return;
+    }
     this.getWPSProcessList().then((response) => {
       if (response === 'success') {
         this.setState({ wpsInfoFetched: true });
@@ -539,6 +546,9 @@ class WPSDemoCopernicus extends Component {
     const { errorExists, errorContent, formNoInputFound } = this.state;
     const { wpsFormElements } = this.state;
     // console.log(this.state);
+    if (!compute) {
+      return (<div style={{margin:'20px'}}><Alert color='info'>You need to sign in to use this functionality</Alert></div>);
+    }
     if (isBusy) {
       return (
         <div>
@@ -620,7 +630,7 @@ class WPSDemoCopernicus extends Component {
                       </Card> : ''
                   }
                 </div>
-                : <div>You need to sign in to use this functionality</div>}
+                : <div>No compute nodes found, maybe you need to sign in?</div>}
             </Col>
           </Row>
           <Row>
@@ -638,7 +648,7 @@ class WPSDemoCopernicus extends Component {
 }
 
 WPSDemoCopernicus.propTypes = {
-  compute: PropTypes.array.isRequired,
+  compute: PropTypes.array,
   dispatch: PropTypes.func.isRequired,
   actions: PropTypes.object.isRequired,
   nrOfStartedProcesses: PropTypes.number,

--- a/src/containers/Diagnostics/DiagnosticPage.jsx
+++ b/src/containers/Diagnostics/DiagnosticPage.jsx
@@ -211,17 +211,18 @@ class DiagnosticPage extends Component {
 
               <Row>
                 <Col xs='6' className='diagnosticsCol'>
+
                   <div className='text'>
-                    <h2 style={{ color: '#921A36' }}>Partners</h2>
-                    {this.renderPageElement('partner')}
+                    <h2 style={{ color: '#921A36' }}>Description</h2>
+                    {this.renderPageElement('description_short')}
+                    <div className='text vspace1em'>
+                      <Button color='primary' onClick={this.readMore}><Icon name='' />&nbsp;Read more</Button>{' '}
+                    </div>
                   </div>
 
                   <div className='text vspace2em'>
-                    <h2 style={{ color: '#921A36' }}>Description</h2>
-                    {this.renderPageElement('description_short')}
-                    <div className='text vspace2em'>
-                      <Button color='primary' onClick={this.readMore}><Icon name='' />&nbsp;Read more</Button>{' '}
-                    </div>
+                    <h2 style={{ color: '#921A36' }}>Partners</h2>
+                    {this.renderPageElement('partner')}
                   </div>
 
                   <div className='text vspace2em'>
@@ -230,52 +231,76 @@ class DiagnosticPage extends Component {
                   </div>
 
                   <div className='text vspace2em'>
-                    <h2 style={{ color: '#921A36' }}>References</h2>
-                    {this.renderPageElement('references')}
-                  </div>
-
-                  <div className='text vspace2em'>
                     <h2 style={{ color: '#921A36' }}>Contact</h2>
                     {this.renderPageElement('contact')}
                   </div>
 
-                  <div className='vspace2em'>
-                    { this.renderPageElement('provenance') && (
-                      <Button className='C3SMagicTooltip' onClick={this.viewProvenance}>
-                        <Icon name='tag' />
-                        &nbsp;Provenance
-                        <span className='C3SMagicTooltipText'>
-                          {
-                            'This describes entities and processes involved in producing the resource. ' +
-                            'Provenance provides a critical foundation for assessing authenticity, enabling trust, and allowing reproducibility.'
-                          }
-                        </span>
-                      </Button>
-                    )
-
-                    }
-                    &nbsp;
-                    { /*  data consisting of single entry */ }
-                    { (this.renderPageElement('data') && !Array.isArray(this.renderPageElement('data'))) && (
-                      <Button className='C3SMagicTooltip' onClick={() => { this.downloadData(this.renderPageElement('data')); }}>
-                        <Icon name='download' />
-                        &nbsp;Download
-                        <span className='C3SMagicTooltipText'>
-                          {
-                            'Download a zipped bundle of all output files'
-                          }
-                        </span>
-                      </Button>) }
-
-                    { /*  data consisting of multiple entries */ }
-                    { (this.renderPageElement('data') && Array.isArray(this.renderPageElement('data'))) && (
-                      <div><h2 style={{ color: '#921A36' }}>Datasets</h2><ul>{this.renderPageElement('data').map((dataUrl, key) => {
-                        return (<li key={key}><Button color='primary' onClick={() => { this.downloadData(dataUrl); }}>
-                          <Icon name='download' />&nbsp;{this.getBasename(dataUrl)}</Button></li>);
-                      })}</ul></div>)
-                    }
+                  <div className='text vspace2em'>
+                    <h2 style={{ color: '#921A36' }}>References</h2>
+                    {this.renderPageElement('references')}
                   </div>
 
+                  {
+                    this.renderPageElement('provenance') && (
+                      <div className='text vspace1em'>
+                        <h2 style={{ color: '#921A36' }}>Provenance</h2>
+                        {
+                          'Provenance describes entities and processes involved in producing the resource. '
+                        }
+                        <ul>
+                          <li>
+                            <Button className='C3SMagicTooltip' onClick={this.viewProvenance}>
+                              <Icon name='tag' />
+                              &nbsp;View Provenance
+                              <span className='C3SMagicTooltipText'>
+                                {
+                                  'This describes entities and processes involved in producing the resource. ' +
+                                  'Provenance provides a critical foundation for assessing authenticity, enabling trust, and allowing reproducibility.'
+                                }
+                              </span>
+                            </Button>
+                          </li>
+                        </ul>
+                      </div>
+                    )
+                  }
+                  {
+                    this.renderPageElement('data') && (
+                      <div className='text vspace1em'>
+                        <h2 style={{ color: '#921A36' }}>Download</h2>
+                        Download precalculated results for this metric as a zipped bundle.<br />
+                        <ul>
+                          { /*  data consisting of single entry */ }
+                          { !Array.isArray(this.renderPageElement('data')) && (
+                            <li>
+                              
+                              <Button className='C3SMagicTooltip' onClick={() => { this.downloadData(this.renderPageElement('data')); }}>
+                                <Icon name='download' />
+                                &nbsp;Download bundle
+                                <span className='C3SMagicTooltipText'>
+                                  {
+                                    'Download a zipped bundle of all output files, ESMValTool logfiles and intermediate files.'
+                                  }
+                                </span>
+                              </Button>
+                            </li>
+                          )
+                          }
+                          { /*  data consisting of multiple entries */ }
+                          { Array.isArray(this.renderPageElement('data')) && (
+                            this.renderPageElement('data').map((dataUrl, key) => {
+                              return (<li key={key}>
+                                <Button color='primary' onClick={() => { this.downloadData(dataUrl); }}>
+                                  <Icon name='download' />&nbsp;{this.getBasename(dataUrl)}
+                                </Button>
+                              </li>);
+                            })
+                          )
+                          }
+                        </ul>
+                      </div>
+                    )
+                  }
                 </Col>
                 <Col xs='6' className='diagnosticsCol'>
 
@@ -302,26 +327,27 @@ class DiagnosticPage extends Component {
                     <h2 style={{ color: '#921A36' }}>Settings</h2>
                     {this.renderPageElement('settings')}
                     { this.renderPageElement('process') ? <div>
-                      <p>You can change the settings above in order to calculate your own result:</p>
+                      <p>You can change the settings above in order to calculate your own result.</p>
                       <Button onClick={this.calculate}><Icon name='gear' />&nbsp;Adjust settings</Button>
                     </div>
                       : null }
                   </div>
                 </Col>
-              </Row>l
-              <Row>
-                <Col xs='12' className='diagnosticsCol'>
-                  <div className='text'>
-                    {this.isEnabled('chart')
-                      ? <div key={'chart'} className='text'>
-                        <h2 style={{ color: '#921A36' }}>Interactive chart</h2>
-                        <DiagnosticsChart data={this.renderPageElement('chart')} />
-                      </div>
-                      : null
-                    }
-                  </div>
-                </Col>
               </Row>
+              {
+                this.isEnabled('chart') && (
+                  <Row>
+                    <Col xs='12' className='diagnosticsCol'>
+                      <div className='text'>
+                        <div key={'chart'} className='text'>
+                          <h2 style={{ color: '#921A36' }}>Interactive chart</h2>
+                          <DiagnosticsChart data={this.renderPageElement('chart')} />
+                        </div>
+                      </div>
+                    </Col>
+                  </Row>
+                )
+              }
               <Row>
                 <Col xs='12' className='diagnosticsCol'>
                   <div className='text vspace2em'>

--- a/src/containers/Diagnostics/DiagnosticPage.jsx
+++ b/src/containers/Diagnostics/DiagnosticPage.jsx
@@ -321,10 +321,11 @@ class DiagnosticPage extends Component {
 
                   <div className='text vspace2em'>
                     <h2 style={{ color: '#921A36' }}>Settings</h2>
+                    <p>Settings for the pre-calculated results.</p>
                     {this.renderPageElement('settings')}
                     { this.renderPageElement('process') ? <div>
-                      <p>You can change the settings above in order to calculate your own result.</p>
-                      <Button onClick={this.calculate}><Icon name='gear' />&nbsp;Adjust settings</Button>
+                      <p>You can calculate this metric yourself using custom settings.</p>
+                      <Button onClick={this.calculate}><Icon name='gear' />&nbsp;Calculate metric</Button>
                     </div>
                       : null }
                   </div>

--- a/src/containers/Diagnostics/DiagnosticPage.jsx
+++ b/src/containers/Diagnostics/DiagnosticPage.jsx
@@ -247,20 +247,16 @@ class DiagnosticPage extends Component {
                         {
                           'Provenance describes entities and processes involved in producing the resource. '
                         }
-                        <ul>
-                          <li>
-                            <Button className='C3SMagicTooltip' onClick={this.viewProvenance}>
-                              <Icon name='tag' />
-                              &nbsp;View Provenance
-                              <span className='C3SMagicTooltipText'>
-                                {
-                                  'This describes entities and processes involved in producing the resource. ' +
-                                  'Provenance provides a critical foundation for assessing authenticity, enabling trust, and allowing reproducibility.'
-                                }
-                              </span>
-                            </Button>
-                          </li>
-                        </ul>
+                        <Button className='C3SMagicTooltip' onClick={this.viewProvenance}>
+                          <Icon name='tag' />
+                          &nbsp;View Provenance
+                          <span className='C3SMagicTooltipText'>
+                            {
+                              'This describes entities and processes involved in producing the resource. ' +
+                              'Provenance provides a critical foundation for assessing authenticity, enabling trust, and allowing reproducibility.'
+                            }
+                          </span>
+                        </Button>
                       </div>
                     )
                   }
@@ -269,35 +265,33 @@ class DiagnosticPage extends Component {
                       <div className='text vspace1em'>
                         <h2 style={{ color: '#921A36' }}>Download</h2>
                         Download precalculated results for this metric as a zipped bundle.<br />
-                        <ul>
-                          { /*  data consisting of single entry */ }
-                          { !Array.isArray(this.renderPageElement('data')) && (
-                            <li>
-                              
-                              <Button className='C3SMagicTooltip' onClick={() => { this.downloadData(this.renderPageElement('data')); }}>
-                                <Icon name='download' />
-                                &nbsp;Download bundle
-                                <span className='C3SMagicTooltipText'>
-                                  {
-                                    'Download a zipped bundle of all output files, ESMValTool logfiles and intermediate files.'
-                                  }
-                                </span>
-                              </Button>
-                            </li>
-                          )
-                          }
-                          { /*  data consisting of multiple entries */ }
-                          { Array.isArray(this.renderPageElement('data')) && (
-                            this.renderPageElement('data').map((dataUrl, key) => {
-                              return (<li key={key}>
-                                <Button color='primary' onClick={() => { this.downloadData(dataUrl); }}>
-                                  <Icon name='download' />&nbsp;{this.getBasename(dataUrl)}
-                                </Button>
-                              </li>);
-                            })
-                          )
-                          }
-                        </ul>
+                        { /*  data consisting of single entry */ }
+                        { !Array.isArray(this.renderPageElement('data')) && (
+                          <Button className='C3SMagicTooltip' onClick={() => { this.downloadData(this.renderPageElement('data')); }}>
+                            <Icon name='download' />
+                            &nbsp;Download bundle
+                            <span className='C3SMagicTooltipText'>
+                              {
+                                'Download a zipped bundle of all output files, ESMValTool logfiles and intermediate files.'
+                              }
+                            </span>
+                          </Button>
+                        )
+                        }
+                        { /*  data consisting of multiple entries */ }
+                        { Array.isArray(this.renderPageElement('data')) && (
+                          <ul>
+                            {
+                              this.renderPageElement('data').map((dataUrl, key) => {
+                                return (<li key={key}>
+                                  <Button color='primary' onClick={() => { this.downloadData(dataUrl); }}>
+                                    <Icon name='download' />&nbsp;{this.getBasename(dataUrl)}
+                                  </Button>
+                                </li>);
+                              })
+                            }
+                          </ul>)
+                        }
                       </div>
                     )
                   }

--- a/src/containers/Diagnostics/DiagnosticPage.jsx
+++ b/src/containers/Diagnostics/DiagnosticPage.jsx
@@ -15,8 +15,12 @@ import ClickableImage from '../../components/ClickableImage';
 import { Row, Col, Button, Alert, Container } from 'reactstrap';
 import Icon from 'react-fa';
 import RenderWPSProcessOutput from '../../components/WPS/RenderWPSProcessOutput';
-var $RefParser = require('json-schema-ref-parser');
+import { getConfig } from '../../getConfig';
+const YAML = require('yamljs');
 var _ = require('lodash');
+
+// import { WMJSLayer, WMJSGetServiceFromStore } from 'adaguc-webmapjs';
+let config = getConfig();
 
 class DiagnosticPage extends Component {
   constructor (props) {
@@ -37,11 +41,13 @@ class DiagnosticPage extends Component {
   readYaml () {
     var yamlPath = 'diagnosticsdata/' + this.props.params.diag + '/' + this.props.params.diag + '.yml';
     this.setState({ yamlPath: yamlPath });
-    var that = this;
-    $RefParser.dereference(yamlPath)
-      .then(data => {
-        that.setState({ yamlData: data, readSuccess: true });
+    fetch(yamlPath).then((response) => {
+      return response.text().then((text) => {
+        text = text.replace('{DATAURL}', config.dataURL);
+        text = text.replace('{STATICWMS}', config.staticWMS);
+        this.setState({ yamlData: YAML.parse(text), readSuccess: true });
       });
+    });
   }
 
   componentDidMount () {

--- a/src/containers/Diagnostics/DiagnosticPage.jsx
+++ b/src/containers/Diagnostics/DiagnosticPage.jsx
@@ -247,6 +247,8 @@ class DiagnosticPage extends Component {
                         {
                           'Provenance describes entities and processes involved in producing the resource. '
                         }
+                        <br />
+                        <br />
                         <Button className='C3SMagicTooltip' onClick={this.viewProvenance}>
                           <Icon name='tag' />
                           &nbsp;View Provenance
@@ -264,7 +266,7 @@ class DiagnosticPage extends Component {
                     this.renderPageElement('data') && (
                       <div className='text vspace1em'>
                         <h2 style={{ color: '#921A36' }}>Download</h2>
-                        Download precalculated results for this metric as a zipped bundle.<br />
+                        Download precalculated results for this metric as a zipped bundle.<br /><br />
                         { /*  data consisting of single entry */ }
                         { !Array.isArray(this.renderPageElement('data')) && (
                           <Button className='C3SMagicTooltip' onClick={() => { this.downloadData(this.renderPageElement('data')); }}>

--- a/src/containers/Diagnostics/DiagnosticsHome.jsx
+++ b/src/containers/Diagnostics/DiagnosticsHome.jsx
@@ -2,8 +2,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Badge, Container, Row, Col, Card, CardImg, CardText, CardSubtitle, CardBody } from 'reactstrap';
-
-var $RefParser = require('json-schema-ref-parser');
+import { getConfig } from '../../getConfig';
+let config = getConfig();
+const YAML = require('yamljs');
+// var $RefParser = require('json-schema-ref-parser');
 
 export default class DiagnosticsHome extends Component {
   constructor (props) {
@@ -83,11 +85,13 @@ export default class DiagnosticsHome extends Component {
   }
 
   componentDidMount () {
-    var that = this;
-    $RefParser.dereference('diagnosticsdata/index.yml')
-      .then(data => {
-        that.setState({ diagList: data.diagnostics });
+    fetch('diagnosticsdata/index.yml').then((response) => {
+      return response.text().then((text) => {
+        text = text.replace('{DATAURL}', config.dataURL);
+        text = text.replace('{STATICWMS}', config.staticWMS);
+        this.setState({ diagList: YAML.parse(text).diagnostics, readSuccess: true });
       });
+    });
   }
 
   componentWillMount () {

--- a/src/static/config.js
+++ b/src/static/config.js
@@ -1,9 +1,6 @@
 const config = {};
 config.adagucViewerURL = 'http://portal.c3s-magic.eu/adaguc-viewer/';
-config.staticWMS='https://portal.c3s-magic.eu/backend/wms';
-// config.backendHost = 'https://localportal.c3s-magic.eu:7777';
+config.staticWMS='https://portal-dev.c3s-magic.eu/backend/wms';
+config.dataURL = 'https://portal-dev.c3s-magic.eu/';
 config.backendHost = 'https://portal-dev.c3s-magic.eu/backend/';
-// config.backendHost = 'https://localportal.c3s-magic.eu/backend/';
-// config.backendHost = 'https://portal.c3s-magic.eu/backend/';
 // config.backendHost = 'https://magicvm/backend/';
-config.backendHost = 'https://portal-dev.c3s-magic.eu/backend/';

--- a/src/static/config.js
+++ b/src/static/config.js
@@ -5,4 +5,5 @@ config.staticWMS='https://portal.c3s-magic.eu/backend/wms';
 config.backendHost = 'https://portal-dev.c3s-magic.eu/backend/';
 // config.backendHost = 'https://localportal.c3s-magic.eu/backend/';
 // config.backendHost = 'https://portal.c3s-magic.eu/backend/';
-config.backendHost = 'https://magicvm/backend/';
+// config.backendHost = 'https://magicvm/backend/';
+config.backendHost = 'https://portal-dev.c3s-magic.eu/backend/';

--- a/src/static/config.js
+++ b/src/static/config.js
@@ -1,9 +1,8 @@
 const config = {};
-// config.backendHost = 'https://portal.c3s-magic.eu/'; // <-- If you dont run your own backend use the magic one
 config.adagucViewerURL = 'http://portal.c3s-magic.eu/adaguc-viewer/';
 config.staticWMS='https://portal.c3s-magic.eu/backend/wms';
 // config.backendHost = 'https://localportal.c3s-magic.eu:7777';
 config.backendHost = 'https://portal-dev.c3s-magic.eu/backend/';
 // config.backendHost = 'https://localportal.c3s-magic.eu/backend/';
 // config.backendHost = 'https://portal.c3s-magic.eu/backend/';
-// export const config = { 'backendHost': 'https://compute-test.c3s-magic.eu:7777', 'adagucServicesHost': 'https://compute-test.c3s-magic.eu:8888' };
+config.backendHost = 'https://magicvm/backend/';

--- a/src/static/diagnosticsdata/surge_height/surge_height.yml
+++ b/src/static/diagnosticsdata/surge_height/surge_height.yml
@@ -11,7 +11,7 @@ description_file: 'surge_height/description.md'
 report_file: report.pdf
 #media: https://placeholdit.imgix.net/~text?txtsize=33&txt=Place%20Holder%20Image&w=512&h=360
 enableADAGUC:
-  - data_url: https://portal.c3s-magic.eu/backend/adagucserver?source=c3smagic%2FWP7-surge_estimator%2Fsurge_heights_EC-Earth_s01r14_20131201-20140131.nc&
+  - data_url: "{STATICWMS}?source=c3smagic%2FWP7-surge_estimator%2Fsurge_heights_EC-Earth_s01r14_20131201-20140131.nc&"
   - projectionbutton: false
   - layerselector: false
   - timeselector: true
@@ -22,7 +22,7 @@ settings:
   - End year: 2014
 references:
 image_file: diagnosticsdata/surge_height/surge_height_thumbnail.png
-data: https://portal.c3s-magic.eu/data/recipes/recipe_modes_of_variability_wp4_20181210_114624.zip
+data: "{DATAURL}/data/recipes/recipe_modes_of_variability_wp4_20181210_114624.zip"
 #provenance: <point to svg file>
 #process: <link to process> 
 #data:

--- a/src/styles/core.scss
+++ b/src/styles/core.scss
@@ -403,7 +403,7 @@ iframe {
 
 .MainViewport h2{
   font-size:24px;
-  padding-bottom:0.5em;
+  // padding-bottom:0.5em;
 }
 
 
@@ -614,6 +614,21 @@ aside, header, main {
 .diagCard {
   cursor:pointer;
 }
+
+div.vspace1em {
+  clear: both;
+  margin-top: 1em;
+
+  flex: 1;
+  flex-direction: column;
+  overflow-x: hidden;
+  display:block;
+  height:inherit;
+  width:inherit;
+  text-align: justify;
+  text-justify: inter-word;
+}
+
 
 div.vspace2em {
   clear: both;


### PR DESCRIPTION
- Sign in message is now showing up properly
- Basket now highlights selected item and requires double click to open…
- Added compute node selector
- In YML files the {DATAURL} and {STATICWMS} will be substituted by the same environment variables as passed to the Docker
- Provenance and download buttons have proper texts
- Moved items in diagnostics page and fixed some whitespace issues